### PR TITLE
Improve Selection UI

### DIFF
--- a/src/common/video.service.ts
+++ b/src/common/video.service.ts
@@ -92,7 +92,7 @@ export default class VideoService {
     targetScale: number
   ) {
     const targetMinimumSize =
-      ((parameters.audioRate * parameters.duration) / 8192) * 1024 * 1024;
+      ((parameters.audioRate * parameters.duration) / 8192);
 
     if (targetMinimumSize > targetSize) {
       return store.commit("consoleErr", "Target size too small");

--- a/src/common/video.service.ts
+++ b/src/common/video.service.ts
@@ -81,7 +81,8 @@ export default class VideoService {
 
     const parameters = this.getTargetParameters(videoInfo, targetSize);
 
-    return (parameters.audioRate * parameters.duration) / 8192;
+    // The final *1024 is to convert back to bytes
+    return ((parameters.audioRate * parameters.duration) / 8192) * 1024 * 1024;
   }
 
   private async transcode(
@@ -91,7 +92,7 @@ export default class VideoService {
     targetScale: number
   ) {
     const targetMinimumSize =
-      (parameters.audioRate * parameters.duration) / 8192;
+      ((parameters.audioRate * parameters.duration) / 8192) * 1024 * 1024;
 
     if (targetMinimumSize > targetSize) {
       return store.commit("consoleErr", "Target size too small");

--- a/src/components/Transcoder.vue
+++ b/src/components/Transcoder.vue
@@ -154,12 +154,9 @@ const onFileChanged = async (event: Event) => {
   store.commit("ffFilesize", target.files[0].size);
 
   // Adjust targetSize if targetSize > originalSize (bytes -> MB)
-  if (1 > Number(target.files[0].size)/1024/1024) {
-    // If originalSize is smaller than 1 MB, just use the originalSize
+  if (8 > Number(target.files[0].size)/1024/1024) {
+    // If originalSize is smaller than 8 MB, just use the originalSize
     targetSize.value = Number(target.files[0].size)/1024/1024;
-  } else if (8 > Number(target.files[0].size)/1024/1024) {
-    // Use integer value between 1 - 8 MB
-    targetSize.value = Math.floor(Number(target.files[0].size)/1024/1024);
   } else {
     // Reset to 8 MB for all videos larger than 8 MB
     targetSize.value = 8;

--- a/src/components/Transcoder.vue
+++ b/src/components/Transcoder.vue
@@ -164,7 +164,7 @@ onMounted(() => {
 const onFileChanged = async (event: Event) => {
   const target = event.target as HTMLInputElement;
 
-  if (!target.files) {
+  if (!target.files || !targetSize.value) {
     return store.commit("consoleErr", "No file selected");
   }
   store.commit("consoleErr", "");
@@ -246,7 +246,7 @@ export default {
       while (n >= 1024 && ++l) {
         n = n / 1024;
       }
-      return n.toFixed(n < 10 && l > 0 ? 1 : 0) + " " + units[l];
+      return n.toFixed(n < 10 && l > 0 ? 2 : 0) + " " + units[l];
     },
   },
 };

--- a/src/components/Transcoder.vue
+++ b/src/components/Transcoder.vue
@@ -12,6 +12,12 @@
             accept="video/mp4"
             v-on:change="onFileChanged"
           />
+          <div class="pt-2 pb-2 text-sm text-gray-300">
+            <span class="text-xs px-3 py-1 bg-161616/50 text-gray-300 rounded select-none mr-1">Original</span>
+            {{ store.state.ffFilesize ? sizeBytes(Number(store.state.ffFilesize)) : "-" }}
+            <span class="text-xs px-3 py-1 bg-161616/50 text-gray-300 rounded select-none ml-2 mr-1">Minimum</span>
+            {{ minimumSize ? sizeBytes(Number(minimumSize)) : "-" }}
+          </div>
         </div>
         <div class="pb-6">
           <div class="pb-2 font-bold">Choose your size</div>
@@ -21,11 +27,6 @@
             v-model="targetSize"
           />
           MB
-          <div class="pt-2 pb-2 text-sm text-gray-300">
-            <span class="text-xs px-3 py-1 bg-161616/50 text-gray-300 rounded select-none mr-1">Original</span>
-            {{ store.state.ffFilesize ? sizeBytes(Number(store.state.ffFilesize)) : "-" }}
-            <span class="text-xs px-3 py-1 bg-161616/50 text-gray-300 rounded select-none ml-2 mr-1">Minimum</span>
-            {{ minimumSize ? sizeBytes(Number(minimumSize)) : "-" }}</div>
         </div>
         <div class="pb-6">
           <div class="pb-2 font-bold">Choose video resolution</div>
@@ -46,8 +47,15 @@
         </div>
         <div class="pb-2 text-right">
           <button
-            class="bg-indigo-800 hover:bg-indigo-700 transition-colors duration-150 px-4 py-2 rounded text-gray-200"
+            class="bg-161616/50 transition-colors duration-150 px-4 py-2 rounded text-gray-200 cursor-default select-none"
+            v-if="store.state.ffFileOkPre"
+          >
+            <span class="inline-block animate-pulse">⏳&ensp;Compress</span>
+          </button>
+          <button
+            class="bg-indigo-800 hover:bg-indigo-700 transition-colors duration-150 px-4 py-2 rounded text-gray-200 select-none"
             v-on:click="onSubmit"
+            v-else
           >
             🦋&ensp;Compress
           </button>
@@ -85,6 +93,13 @@
           >
             Compress new video
           </button>
+        </div>
+        <div
+          class="pt-2 pb-2"
+          v-if="store.state.consoleErr"
+        >
+          <span class="absolute transition-all duration-150">⚠</span>
+          <span class="ml-8">{{ store.state.consoleErr }}</span>
         </div>
       </div>
 
@@ -153,6 +168,7 @@ const onFileChanged = async (event: Event) => {
     return store.commit("consoleErr", "No file selected");
   }
   store.commit("consoleErr", "");
+  store.commit("ffFileOkPre", true);
   inputFile.value = target.files[0];
   store.commit("ffFilename", target.files[0].name);
   store.commit("ffFilesize", target.files[0].size);
@@ -178,6 +194,7 @@ const onFileChanged = async (event: Event) => {
     target.files[0],
     targetScale.value
   )) as number;
+  store.commit("ffFileOkPre", false);
 };
 
 // onSubmit - called when submit button is pressed245
@@ -185,10 +202,14 @@ const onFileChanged = async (event: Event) => {
 const onSubmit = async () => {
   if (!inputFile.value) {
     return store.commit("consoleErr", "No file selected");
-  }
+  };
   if (store.state.ffFilesize < Number(targetSize.value) * 1024 * 1024) {
     return store.commit("consoleErr", "File is smaller than your target size!");
-  }
+  };
+  console.log(targetSize.value, Number(minimumSize.value)/1024/1024);
+  if (targetSize.value < Number(minimumSize.value)/1024/1024) {
+    return store.commit("consoleErr", "Target size is too small!");
+  };
 
   store.commit("ffFileOk", true);
 

--- a/src/components/Transcoder.vue
+++ b/src/components/Transcoder.vue
@@ -21,7 +21,11 @@
             v-model="targetSize"
           />
           MB
-          <div class="pt-2 pb-2 text-sm text-gray-300">Original size: {{ store.state.ffFilesize ? sizeBytes(Number(store.state.ffFilesize)) : "-" }}</div>
+          <div class="pt-2 pb-2 text-sm text-gray-300">
+            <span class="text-xs px-3 py-1 bg-161616/50 text-gray-300 rounded select-none mr-1">Original</span>
+            {{ store.state.ffFilesize ? sizeBytes(Number(store.state.ffFilesize)) : "-" }}
+            <span class="text-xs px-3 py-1 bg-161616/50 text-gray-300 rounded select-none ml-2 mr-1">Minimum</span>
+            {{ minimumSize ? sizeBytes(Number(minimumSize)) : "-" }}</div>
         </div>
         <div class="pb-6">
           <div class="pb-2 font-bold">Choose video resolution</div>
@@ -154,10 +158,10 @@ const onFileChanged = async (event: Event) => {
   store.commit("ffFilesize", target.files[0].size);
 
   // Adjust targetSize if targetSize > originalSize (bytes -> MB)
-  if (8 > Number(target.files[0].size)/1024/1024) {
+  if (targetSize.value > Number(target.files[0].size)/1024/1024) {
     // If originalSize is smaller than 8 MB, just use the originalSize
     targetSize.value = Number(target.files[0].size)/1024/1024;
-  } else {
+  } else if (targetSize.value < 8) {
     // Reset to 8 MB for all videos larger than 8 MB
     targetSize.value = 8;
   };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -6,6 +6,7 @@ export interface State {
   consoleMsg: string;
   ffFilename: string;
   ffFileOk: boolean;
+  ffFileOkPre: boolean;
   ffFilesize: number;
   ffProgress: number;
 }
@@ -18,6 +19,7 @@ export const store = createStore<State>({
     consoleMsg: "",
     ffFilename: "",
     ffFileOk: false,
+    ffFileOkPre: false,
     ffFilesize: 0,
     ffProgress: 0,
   },
@@ -33,6 +35,9 @@ export const store = createStore<State>({
     },
     ffFileOk(state, data) {
       state.ffFileOk = data;
+    },
+    ffFileOkPre(state, data) {
+      state.ffFileOkPre = data;
     },
     ffFilesize(state, data) {
       state.ffFilesize = data;


### PR DESCRIPTION
- Fix #8 
  - [x] Add message space for both original file size and minimum file size
  - [x] Add minimum file size indicator
  - [x] Return targetMinimumSize in bytes
  
- Fix #9 
  - [x] Add selectable buttons for easier resolution changing
  - [x] Add message space for suggested resolution message
  - [x] Automatically suggest resolution based on compression ratio
  
- Fix #10
  - [x] Allow keeping size constant and only changing resolution
  - [x] Automatically adjust default file size limit based on input file
  
- Other improvements:
  - [x] Standardize file size display during transcoding 
